### PR TITLE
Passing the calendar object to the new page

### DIFF
--- a/library/src/main/java/com/applandeo/materialcalendarview/CalendarView.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/CalendarView.java
@@ -256,11 +256,14 @@ public class CalendarView extends LinearLayout {
             if (!isScrollingLimited(calendar, position)) {
                 setHeaderName(calendar, position);
             }
+
         }
 
         @Override
         public void onPageScrollStateChanged(int state) {
+
         }
+
     };
 
     private boolean isScrollingLimited(Calendar calendar, int position) {
@@ -279,20 +282,22 @@ public class CalendarView extends LinearLayout {
 
     private void setHeaderName(Calendar calendar, int position) {
         mCurrentMonthLabel.setText(DateUtils.getMonthAndYearDate(mContext, calendar));
-        callOnPageChangeListeners(position);
+        callOnPageChangeListeners(calendar, position);
     }
 
     // This method calls page change listeners after swipe calendar or click arrow buttons
-    private void callOnPageChangeListeners(int position) {
+    private void callOnPageChangeListeners(Calendar calendar, int position) {
+
         if (position > mCurrentPage && mCalendarProperties.getOnForwardPageChangeListener() != null) {
-            mCalendarProperties.getOnForwardPageChangeListener().onChange();
+            mCalendarProperties.getOnForwardPageChangeListener().onChange(calendar);
         }
 
         if (position < mCurrentPage && mCalendarProperties.getOnPreviousPageChangeListener() != null) {
-            mCalendarProperties.getOnPreviousPageChangeListener().onChange();
+            mCalendarProperties.getOnPreviousPageChangeListener().onChange(calendar);
         }
 
         mCurrentPage = position;
+
     }
 
     /**

--- a/library/src/main/java/com/applandeo/materialcalendarview/adapters/CalendarPageAdapter.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/adapters/CalendarPageAdapter.java
@@ -16,7 +16,7 @@ import com.applandeo.materialcalendarview.utils.SelectedDay;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
+import java.util.HashSet;
 
 /**
  * This class is responsible for loading a calendar page content.
@@ -35,7 +35,7 @@ public class CalendarPageAdapter extends PagerAdapter {
     private Context mContext;
     private CalendarGridView mCalendarGridView;
 
-    private List<SelectedDay> mSelectedDays = new ArrayList<>();
+    private HashSet<SelectedDay> mSelectedDays = new HashSet<>();
 
     private CalendarProperties mCalendarProperties;
 
@@ -90,12 +90,15 @@ public class CalendarPageAdapter extends PagerAdapter {
         informDatePicker();
     }
 
-    public List<SelectedDay> getSelectedDays() {
+    public HashSet<SelectedDay> getSelectedDays() {
         return mSelectedDays;
     }
 
     public SelectedDay getSelectedDay() {
-        return mSelectedDays.get(0);
+        if(!mSelectedDays.isEmpty())
+            return mSelectedDays.iterator().next();
+        else
+            return null;
     }
 
     public void setSelectedDay(SelectedDay selectedDay) {
@@ -119,6 +122,8 @@ public class CalendarPageAdapter extends PagerAdapter {
      * @param position Position of current page in ViewPager
      */
     private void loadMonth(int position) {
+
+
         ArrayList<Date> days = new ArrayList<>();
 
         // Get Calendar object instance

--- a/library/src/main/java/com/applandeo/materialcalendarview/listeners/DayRowClickListener.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/listeners/DayRowClickListener.java
@@ -17,7 +17,7 @@ import com.applandeo.materialcalendarview.utils.SelectedDay;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.List;
+import java.util.HashSet;
 
 /**
  * This class is responsible for handle click events
@@ -99,7 +99,7 @@ public class DayRowClickListener implements AdapterView.OnItemClickListener {
             return;
         }
 
-        List<SelectedDay> selectedDays = mCalendarPageAdapter.getSelectedDays();
+        HashSet<SelectedDay> selectedDays = mCalendarPageAdapter.getSelectedDays();
 
         if (selectedDays.size() > 1) {
             clearAndSelectOne(dayLabel, day);

--- a/library/src/main/java/com/applandeo/materialcalendarview/listeners/OnCalendarPageChangeListener.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/listeners/OnCalendarPageChangeListener.java
@@ -1,9 +1,11 @@
 package com.applandeo.materialcalendarview.listeners;
 
+import java.util.Calendar;
+
 /**
  * Created by Mateusz Kornakiewicz on 12.10.2017.
  */
 
 public interface OnCalendarPageChangeListener {
-    void onChange();
+    void onChange(Calendar newDate);
 }

--- a/sample/src/main/java/com/applandeo/materialcalendarsampleapp/ManyDaysPickerActivity.java
+++ b/sample/src/main/java/com/applandeo/materialcalendarsampleapp/ManyDaysPickerActivity.java
@@ -6,6 +6,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.applandeo.materialcalendarview.CalendarView;
+import com.applandeo.materialcalendarview.listeners.OnCalendarPageChangeListener;
 
 import java.util.Calendar;
 
@@ -22,11 +23,24 @@ public class ManyDaysPickerActivity extends AppCompatActivity {
 
         CalendarView calendarView = (CalendarView) findViewById(R.id.calendarView);
 
-        calendarView.setOnForwardPageChangeListener(() ->
-                Toast.makeText(getApplicationContext(), "Forward", Toast.LENGTH_SHORT).show());
+        calendarView.setOnForwardPageChangeListener(new OnCalendarPageChangeListener() {
+            @Override
+            public void onChange(Calendar newDate) {
+                Toast.makeText(getApplicationContext(),
+                        "New page is: " + newDate.get(Calendar.YEAR) +"" +newDate.get(Calendar.MONTH)
+                        , Toast.LENGTH_SHORT).show();
 
-        calendarView.setOnPreviousPageChangeListener(() ->
-                Toast.makeText(getApplicationContext(), "Previous", Toast.LENGTH_SHORT).show());
+            }
+        });
+
+        calendarView.setOnPreviousPageChangeListener(new OnCalendarPageChangeListener() {
+            @Override
+            public void onChange(Calendar newDate) {
+                Toast.makeText(getApplicationContext(),
+                        "New page is: " + newDate.get(Calendar.YEAR) +"" +newDate.get(Calendar.MONTH)
+                        , Toast.LENGTH_SHORT).show();
+            }
+        });
 
         Button getDateButton = (Button) findViewById(R.id.getDateButton);
         getDateButton.setOnClickListener(v -> {


### PR DESCRIPTION
Hi
Passing the calendar object to the new page would be very helpful especially when the user have to add many selected days in the calendar, e.g. 5000 days in 20 years range.
If the library gives the user the current date, it would be way more efficient to update the page when the user navigate to it.

Could you merge it please?

Thanks

- Edited: OnPreviousPageChangedListener and OnFollowingPageChangedListener

    + Now, the listeners will have the new page calender object in the callback function

- Edited Sample project, "Many Days Picker" activity and added Toast to show the new page date, year and month

- Some List changed to HashSet as it's proven to be faster