### PR TITLE
Removed a missed retrolambda reference

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'me.tatarka.retrolambda'
 
 ext {
     PUBLISH_GROUP_ID = 'com.applandeo'


### PR DESCRIPTION
When I was attempting to reference the source code from my app, it was blowing up on the retrolambda reference.

I assume that all of retrolambda was removed here: https://github.com/Applandeo/Material-Calendar-View/commit/20f5ce4335cc19a8a81f2da96e7c376bbb45f9d2