### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-    package="com.applandeo.materialcalendarview">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.applandeo.materialcalendarview"/>


### PR DESCRIPTION
Remove unnecessary part. This isn't necessary for a library project. And this won't make necessary to use override the backup and rtl in your application manifest file when build is merging AndroidManifest