### PR TITLE
Added a setEvent option for the DatePickerBuilder

### DIFF
--- a/library/src/main/java/com/applandeo/materialcalendarview/builders/DatePickerBuilder.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/builders/DatePickerBuilder.java
@@ -8,6 +8,7 @@ import android.widget.ListView;
 
 import com.applandeo.materialcalendarview.CalendarView;
 import com.applandeo.materialcalendarview.DatePicker;
+import com.applandeo.materialcalendarview.EventDay;
 import com.applandeo.materialcalendarview.listeners.OnCalendarPageChangeListener;
 import com.applandeo.materialcalendarview.listeners.OnSelectDateListener;
 import com.applandeo.materialcalendarview.utils.CalendarProperties;
@@ -598,5 +599,22 @@ public class DatePickerBuilder {
     public DatePickerBuilder setSelectedDays(List<Calendar> selectedDays) {
         mCalendarProperties.setSelectedDays(selectedDays);
         return this;
+    }
+
+    /**
+     * This method is used to set a list of events displayed in calendar cells,
+     * visible as images under the day number.
+     *
+     * @param eventDays List of EventDay objects
+     * @see EventDay
+     * @return The builder object to allow for chaining of methods
+     */
+    public DatePickerBuilder setEvents(List<EventDay> eventDays) {
+      if (eventDays != null) {
+        mCalendarProperties.setEventsEnabled(true);
+        mCalendarProperties.setEventDays(eventDays);
+      }
+
+      return this;
     }
 }


### PR DESCRIPTION
Automatically set the eventsEnabled on the calendar properties to prevent needing to chain in a specific order.