### PR TITLE
Small change to make it easier for lib users to know info about the d…

### DIFF
--- a/library/src/main/java/com/applandeo/materialcalendarview/EventDay.kt
+++ b/library/src/main/java/com/applandeo/materialcalendarview/EventDay.kt
@@ -24,9 +24,11 @@ import java.util.*
 
 data class EventDay(val calendar: Calendar) {
     //An object which contains image to display in the day row
-    internal var imageDrawable: EventImage = EventImage.EmptyEventImage
+    var imageDrawable: EventImage = EventImage.EmptyEventImage
+        private set
 
-    internal var labelColor: Int = 0
+    var labelColor: Int = 0
+        private set
 
     @set:RestrictTo(RestrictTo.Scope.LIBRARY)
     var isEnabled: Boolean = false


### PR DESCRIPTION
…ate that was tapped

With this change I am now able to do this:
```

        binding.calendarView.setOnDayClickListener(object : OnDayClickListener{
            override fun onDayClick(eventDay: EventDay) {
                when (val drawable = eventDay.imageDrawable){
                    is EventImage.EventImageResource-> {...}
                    is EventImage.EmptyEventImage-> {...}


Before I would need to do a list searches to know if this date was marked with an image.
