### PR TITLE
Fix one day picker crash when selecting a day if no days were previously selected

### DIFF
--- a/library/src/main/java/com/applandeo/materialcalendarview/listeners/DayRowClickListener.java
+++ b/library/src/main/java/com/applandeo/materialcalendarview/listeners/DayRowClickListener.java
@@ -71,13 +71,18 @@ public class DayRowClickListener implements AdapterView.OnItemClickListener {
     }
 
     private void selectOneDay(View view, Calendar day) {
-        SelectedDay previousSelectedDay = mCalendarPageAdapter.getSelectedDay();
+        SelectedDay previousSelectedDay = null;
+        if (mCalendarPageAdapter.getSelectedDays().size() > 0) {
+            previousSelectedDay = mCalendarPageAdapter.getSelectedDay();
+        }
 
         TextView dayLabel = (TextView) view.findViewById(R.id.dayLabel);
 
         if (isAnotherDaySelected(previousSelectedDay, day)) {
             selectDay(dayLabel, day);
             reverseUnselectedColor(previousSelectedDay);
+        } else if (isCurrentMonthDay(day) && isActiveDay(day)) {
+            selectDay(dayLabel, day);
         }
     }
 


### PR DESCRIPTION
The widget led to app crash when selecting a day in the one day picker mode if no days were previously selected.

To mimic this behaviour you can add this code on the sample app, OneDayPickerActivity, row 37:

`

        Calendar today = Calendar.getInstance();

        try {
            calendarView.setDate(today);
        } catch (OutOfDateRangeException e) {
            e.printStackTrace();
        }

        calendarView.setDisabledDays(Collections.singletonList(today));

`

Basically if a day is selected and then disabled, the selection is cleared and, by tapping on another day, the crash happens.

My solution is to check the size of the selected days array before trying to get the first element and also allow to select the tapped day even if there is no day to deselect.